### PR TITLE
Enable refine_template to just reevaluate score

### DIFF
--- a/ax_cuda.m4
+++ b/ax_cuda.m4
@@ -181,7 +181,7 @@ fi
 
 # This is the code that will be generated at compile time and should be specified for the most used gpu 
 target_arch=""
-AC_ARG_WITH([target-gpu-arch], AS_HELP_STRING([--with-target-gpu-arch@<:@=yes|no|DIR@:>@], [Primary architecture to compile for (default=86)]),
+AC_ARG_WITH([target-gpu-arch], AS_HELP_STRING([--with-target-gpu-arch@<:@=60,61,70,75,80,86@:>@], [Primary architecture to compile for (default=86)]),
 [
 	if test "$withval" = "86" ; then target_arch=86 
 	elif  test "$withval" = "80" ; then target_arch=80
@@ -202,7 +202,7 @@ NVCCFLAGS+=" --gpu-architecture=sm_$target_arch -gencode=arch=compute_$target_ar
 
 # This is the oldest arch that will have JIT-able code g
 oldest_arch=""
-AC_ARG_WITH([oldest-gpu-arch], AS_HELP_STRING([--with-oldest-gpu-arch@<:@=yes|no|DIR@:>@], [Oldest architecture make compatible for (default=70)]),
+AC_ARG_WITH([oldest-gpu-arch], AS_HELP_STRING([--with-oldest-gpu-arch@<:@=60,61,70,75,80,86:>@], [Oldest architecture make compatible for (default=70)]),
 [
 	if test "$withval" = "86" ; then oldest_arch=86 
 	elif  test "$withval" = "80" ; then oldest_arch=80
@@ -251,7 +251,7 @@ fi
 #--extra-device-vectorization
 NVCCFLAGS+=" --default-stream per-thread --extra-device-vectorization -m64 -O3 --use_fast_math  -Xptxas --warn-on-local-memory-usage,--warn-on-spills, --generate-line-info -Xcompiler= -std=c++11 -DGPU -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1"
 
-AC_ARG_ENABLE(gpu-cache-hints, [  --disable-gpu-cache-hints          Do not use the intrinsics for cache hints ],[
+AC_ARG_ENABLE(gpu-cache-hints, AS_HELP_STRING([--disable-gpu-cache-hints],[Do not use the intrinsics for cache hints]),[
   if test "$enableval" = no; then
   	NVCCFLAGS+=" -Xcompiler= -DDISABLECACHEHINTS"
   	AC_MSG_NOTICE([Disabling cache hint intrinsics requiring CUDA 11 or newer])  	

--- a/ax_cuda.m4
+++ b/ax_cuda.m4
@@ -45,30 +45,32 @@
 AC_DEFUN([AX_CUDA],
 [
 
-AC_ARG_WITH([cuda],
-    AS_HELP_STRING([--with-cuda@<:@=yes|no|DIR@:>@], [prefix where cuda is installed (default=yes)]),
+# Default install for cuda
+default_cuda_home_path="/usr/local/cuda"
+
+# In Thrust 1.10 c++11 is deprecated. Not using those libs now, so squash warnings, but we should consider switching to a newer standard
+AC_DEFINE(THRUST_IGNORE_DEPRECATED_CPP_11,true)
+
+AC_MSG_NOTICE([Checking for gpu request and vars])
+AC_ARG_WITH([cuda], AS_HELP_STRING([--with-cuda@<:@=yes|no|DIR@:>@], [prefix where cuda is installed (default=no)]),
 [
 	with_cuda=$withval
-  cuda_home_path="/usr/local/cuda"
-	if test "$withval" = "no"
-	then
-		want_cuda="no"
-	elif test "$withval" = "yes"
-	then
+	if test "$withval" = "yes" ; then
 		want_cuda="yes"
-	else
-		want_cuda="yes"
-		cuda_home_path=$withval
+		cuda_home_path=$default_cuda_home_path
+	else 
+		if test "$withval" = "no" ; then
+			want_cuda="no"
+		else
+			want_cuda="yes"
+			cuda_home_path=$withval
+		fi
 	fi
-],
-[
-	want_cuda="no"
-])
+	
+], [ want_cuda="no"] )
 
+if test "$want_cuda" = "yes" ; then
 
-
-if test "$want_cuda" = "yes"
-then
 	# check that nvcc compiler is in the path
 	if test -n "$cuda_home_path"
 	then
@@ -89,23 +91,23 @@ then
 	NVCC_VERSION=`$NVCC --version | grep release | awk 'gsub(/,/, "") {print [$]5}'`
 	AC_MSG_RESULT([nvcc version : $NVCC_VERSION $NVCC_VERSION])
 	
-  # we'll only use 64 bit arch
-  libdir=lib64
+ 	# we'll only use 64 bit arch
+  	libdir=lib64
 
-	# set CUDA flags
+	# set CUDA flags for static compilation. This is required for cufft callbacks.
 	if test -n "$cuda_home_path"
 	then
-	    CUDA_CFLAGS="-I$cuda_home_path/include  -I$cuda_home_path/samples/common/inc/"
+	  CUDA_CFLAGS="-I$cuda_home_path/include  -I$cuda_home_path/samples/common/inc/"
       CUDA_LIBS="-L$cuda_home_path/$libdir -lcufft_static -lnppial_static -lnppist_static -lnppc_static -lcurand_static -lculibos -lcudart_static -lrt"
 	else
-	    CUDA_CFLAGS="-I/usr/local/cuda/include  -I/usr/local/cuda/samples/common/inc/"
-	    CUDA_LIBS="-L/usr/local/cuda/$libdir -lcufft_static -lnppial_static -lnppist_static -lnppc_static -lcurand_static -lculibos -lcudart_static -lrt"
+	  CUDA_CFLAGS="-I/usr/local/cuda/include  -I/usr/local/cuda/samples/common/inc/"
+	  CUDA_LIBS="-L/usr/local/cuda/$libdir -lcufft_static -lnppial_static -lnppist_static -lnppc_static -lcurand_static -lculibos -lcudart_static -lrt"
 	fi
 
 
 	saved_CPPFLAGS=$CPPFLAGS
 	saved_LIBS=$LIBS
-  saved_CUDA_LIBS=$CUDA_LIBS
+  	saved_CUDA_LIBS=$CUDA_LIBS
 
 	# Env var CUDA_DRIVER_LIB_PATH can be used to set an alternate driver library path
 	# this is usefull when building on a host where only toolkit (nvcc) is installed
@@ -122,7 +124,7 @@ then
 
 	AC_LANG_PUSH(C)
 	AC_MSG_CHECKING([for Cuda headers])
-  AC_MSG_NOTICE([cuda path is $cuda_home_path])
+  	AC_MSG_NOTICE([cuda path is $cuda_home_path])
 	AC_COMPILE_IFELSE(
 	[
 		AC_LANG_PROGRAM([@%:@include <cuda.h>], [])
@@ -166,7 +168,7 @@ then
 
 	CPPFLAGS=$saved_CPPFLAGS
 	LIBS=$saved_LIBS
-  CUDA_LIBS=$saved_CUDA_LIBS
+  	CUDA_LIBS=$saved_CUDA_LIBS
 	
 	if test "$have_cuda_headers" = "yes" -a "$have_cuda_libs" = "yes" -a "$have_nvcc" = "yes"
 	then
@@ -177,55 +179,84 @@ then
 	fi
 fi
 
-#AC_SUBST(CUDA_CFLAGS)
-#AC_SUBST(CUDA_LIBS)
-#AC_SUBST(NVCC)
-
-# This is set to default by BAH
-want_fast_math="yes"
-AC_ARG_WITH([cuda-fast-math],
-	[AC_HELP_STRING([--with-cuda-fast-math],
-		[Tell nvcc to use -use_fast_math flag])],
-	[
-		if test "$withval" = "no"
-		then
-			want_fast_math="no"
-		elif test "$withval" = "yes"
-		then
-			want_fast_math="yes"
-		else
-			with_fast_math="$withval"
-			want_fast_math="yes"
-		fi
-	 ],
-         [
-		want_fast_math="yes"
-	 ]
-)
-
+# This is the code that will be generated at compile time and should be specified for the most used gpu 
+target_arch=""
+AC_ARG_WITH([target-gpu-arch], AS_HELP_STRING([--with-target-gpu-arch@<:@=yes|no|DIR@:>@], [Primary architecture to compile for (default=86)]),
+[
+	if test "$withval" = "86" ; then target_arch=86 
+	elif  test "$withval" = "80" ; then target_arch=80
+	elif  test "$withval" = "75" ; then target_arch=75
+	elif  test "$withval" = "70" ; then target_arch=70
+	elif  test "$withval" = "61" ; then target_arch=61
+	elif  test "$withval" = "60" ; then target_arch=60
+	else
+		AC_MSG_ERROR([Requested target-gpu-arch must be in 60,61,70,75,80,86, not $withval])
+	fi
+	
+], [ target_arch="86"] )
+AC_MSG_NOTICE([target gpu architecture is sm$target_arch])
 
 # Default nvcc flags
-
 NVCCFLAGS=" -ccbin $CXX"
-#AC_ARG_ENABLE([emu],
-#    AS_HELP_STRING([--enable-emu], [Turn on device emulation for CUDA]),
-#    [case "${enableval}" in
-#        yes) EMULATION=true ;;
-#        no)  EMULATION=false ;;
-#        *)   AC_MSG_ERROR([bad value ${enableval} for --enable-emu]) ;;
-#    esac],
-#    [EMULATION=false]
-#)
+NVCCFLAGS+=" --gpu-architecture=sm_$target_arch -gencode=arch=compute_$target_arch,code=compute_$target_arch"
 
+# This is the oldest arch that will have JIT-able code g
+oldest_arch=""
+AC_ARG_WITH([oldest-gpu-arch], AS_HELP_STRING([--with-oldest-gpu-arch@<:@=yes|no|DIR@:>@], [Oldest architecture make compatible for (default=70)]),
+[
+	if test "$withval" = "86" ; then oldest_arch=86 
+	elif  test "$withval" = "80" ; then oldest_arch=80
+	elif  test "$withval" = "75" ; then oldest_arch=75
+	elif  test "$withval" = "70" ; then oldest_arch=70
+	elif  test "$withval" = "61" ; then oldest_arch=61
+	elif  test "$withval" = "60" ; then oldest_arch=60
+	else
+		AC_MSG_ERROR([Requested target-oldest_arch must be in 60,61,70,75,80,86, not $withval])
+	fi
+	
+], [ oldest_arch="70"] )
+AC_MSG_NOTICE([oldest gpu architecture is sm$oldest_arch])
 
+if test "$oldest_arch" -gt "$target_arch" ; then 
+	AC_MSG_ERROR([Requested target-oldest_arch is greater than the target arch.]) 
+else
+	current_arch="60"
+	if test "$current_arch" -ge $oldest_arch && test "$current_arch" -lt "$target_arch" ; then
+		NVCCFLAGS+=" -gencode=arch=compute_$current_arch,code=sm_$current_arch"
+	fi
+	
+	current_arch="61"
+	if test "$current_arch" -ge $oldest_arch && test "$current_arch" -lt "$target_arch" ; then
+		NVCCFLAGS+=" -gencode=arch=compute_$current_arch,code=sm_$current_arch"
+	fi
+	
+	current_arch="70"
+	if test "$current_arch" -ge $oldest_arch && test "$current_arch" -lt "$target_arch" ; then
+		NVCCFLAGS+=" -gencode=arch=compute_$current_arch,code=sm_$current_arch"
+	fi	
+	
+	current_arch="75"
+	if test "$current_arch" -ge $oldest_arch && test "$current_arch" -lt "$target_arch" ; then
+		NVCCFLAGS+=" -gencode=arch=compute_$current_arch,code=sm_$current_arch"
+	fi	
+	
+	current_arch="80"
+	if test "$current_arch" -ge $oldest_arch && test "$current_arch" -lt "$target_arch" ; then
+		NVCCFLAGS+=" -gencode=arch=compute_$current_arch,code=sm_$current_arch"
+	fi		
+		
+fi
 
-# For now just compile for Volta and Turing arch
-#NVCCFLAGS+=" --gpu-architecture=compute_70 --gpu-code=sm_70,sm_75"
-#NVCCFLAGS+=" --gpu-architecture=compute_86 -gencode=arch=compute_86,code=sm_86 -gencode=arch=compute_86,code=compute_86 "
-NVCCFLAGS+=" --gpu-architecture=sm_80 -gencode=arch=compute_86,code=compute_86 -gencode=arch=compute_70,code=sm_70  -gencode=arch=compute_75,code=sm_75"
+ 
 #--extra-device-vectorization
-NVCCFLAGS+=" --default-stream per-thread -m64 -O3 --use_fast_math  -Xptxas --warn-on-local-memory-usage,--warn-on-spills, --generate-line-info -Xcompiler= -std=c++11 -DGPU -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1"
+NVCCFLAGS+=" --default-stream per-thread --extra-device-vectorization -m64 -O3 --use_fast_math  -Xptxas --warn-on-local-memory-usage,--warn-on-spills, --generate-line-info -Xcompiler= -std=c++11 -DGPU -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1"
 
+AC_ARG_ENABLE(gpu-cache-hints, [  --disable-gpu-cache-hints          Do not use the intrinsics for cache hints ],[
+  if test "$enableval" = no; then
+  	NVCCFLAGS+=" -Xcompiler= -DDISABLECACHEHINTS"
+  	AC_MSG_NOTICE([Disabling cache hint intrinsics requiring CUDA 11 or newer])  	
+  fi])
+  
 AC_SUBST(CUDA_LIBS)
 AC_SUBST(CUDA_CFLAGS)
 AC_SUBST(NVCCFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -32,13 +32,23 @@ AC_MSG_NOTICE([Setting up initial flags])
 
 
 # check to see if compiler warnings are desired.
-WALLON=""
-AC_ARG_WITH([warnings-on], [Enable compiler warnings], [WALLON="-Wall"])
+
+AC_ARG_ENABLE([disable-warnings], AS_HELP_STRING([--disable compiler warnings], [Default=false]), [
+	if test "x$enableval" = "no" ; then
+		WALLON=""
+		AC_MSG_NOTICE([DISABLE VAL $enableval])
+		
+	else
+		WALLON="-Wall"
+				AC_MSG_NOTICE([ELSE VAL $enableval])
+		
+	fi
+], [WALLON="-Wall"])
 
 
 if test "x$CXX" = "xicpc"; then		
-	CXXFLAGS="$CXXFLAGS -O3 -no-prec-div -no-prec-sqrt -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -std=c++11 -w2 -wd1125"
-	CPPFLAGS="$CPPFLAGS -O3 -no-prec-div -no-prec-sqrt -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE"
+	CXXFLAGS="$CXXFLAGS -O3 -no-prec-div -no-prec-sqrt $WALLON -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -std=c++11 -w2 -wd1125"
+	CPPFLAGS="$CPPFLAGS -O3 -no-prec-div -no-prec-sqrt $WALLON -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE"
 else
 	CXXFLAGS="$CXXFLAGS -DNDEBUG -funroll-loops -O3 -pipe $WALLON -fexpensive-optimizations -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -std=c++11"		
 	CPPFLAGS="$CPPFLAGS -DNDEBUG -funroll-loops -O3 -pipe $WALLON -fexpensive-optimizations -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE"
@@ -78,17 +88,19 @@ AM_CONDITIONAL([WINDOWS_AM], [test "$build_windows" = "yes"])
 AM_CONDITIONAL([OSX_AM], [test "$build_mac" = "yes"])
 
 # Use all available processor instruction sets
-AC_ARG_ENABLE(latest-instruction-set, [  --enable-latest-instruction-set     Use latest available CPU instruction set [[default=yes]]],[
+AC_ARG_ENABLE(latest-instruction-set, AS_HELP_STRING([--enable-latest-instruction-set],[Use latest available CPU instruction set [default=yes]]),[
+        AC_MSG_ERROR(["Enable val by default is $enableval"])
+
   if test "$enableval" = yes; then
 	if test "x$CXX" = "xicpc"; then	
 		CXXFLAGS="$CXXFLAGS -xHost"
 	fi
   fi
-  ])
+])
 
-# MKL
+# MKL FIXME this looks like it is duplicated at line 134
 
-AC_ARG_ENABLE(mkl, [  --disable-mkl           Do not use the Intel MKL ],[
+AC_ARG_ENABLE(mkl, AS_HELP_STRING([--disable-mkl],[Do not use the Intel MKL]),[
   if test "$enableval" = no; then
         use_mkl=0
   fi])
@@ -98,7 +110,7 @@ AC_ARG_ENABLE(mkl, [  --disable-mkl           Do not use the Intel MKL ],[
 
 static_link="false"
 
-AC_ARG_ENABLE(staticmode, [  --enable-staticmode     Link statically [[default=no]]],[
+AC_ARG_ENABLE(staticmode, AS_HELP_STRING([--enable-staticmode],[Link statically [default=no]]),[
   if test "$enableval" = yes; then
 	static_link="true"
 	WXCONFIGFLAGS="--static=yes"
@@ -114,8 +126,8 @@ AM_CONDITIONAL([STATIC_LINKING_AM],[test x$static_link = xtrue])
 
 WXCONFIG=wx-config
 AC_ARG_WITH(wx-config,
-[[  --with-wx-config=FILE   Use the given path to wx-config when determining
-                          wxWidgets configuration; defaults to "wx-config"]],
+AS_HELP_STRING([--with-wx-config=FILE],[Use the given path to wx-config when determining
+                          wxWidgets configuration; defaults to "wx-config"]),
 [
     if test "$withval" != "yes" -a "$withval" != ""; then
         WXCONFIG=$withval
@@ -126,18 +138,18 @@ AC_ARG_WITH(wx-config,
 
 use_mkl=1
 
-AC_ARG_ENABLE(mkl, [  --disable-mkl           Do not use the Intel MKL ],[
+AC_ARG_ENABLE(mkl, AS_HELP_STRING([--disable-mkl],[Do not use the Intel MKL]),[
   if test "$enableval" = no; then
   	use_mkl=0
   fi])
 
 # debugmode
 
-AC_ARG_ENABLE(debugmode, [  --enable-debugmode      Compile in debug mode [[default=no]]],[
+AC_ARG_ENABLE(debugmode, AS_HELP_STRING([--enable-debugmode],[Compile in debug mode [default=no]]),[
   if test "$enableval" = yes; then
   if test "x$CXX" = "xicpc"; then   
-    CXXFLAGS="-O2 -debug -no-prec-div -no-prec-sqrt -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG -std=c++11 -w2 -wd1125"
-    CPPFLAGS="-O2 -debug -no-prec-div -no-prec-sqrt -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG"
+    CXXFLAGS="-O2 -debug -no-prec-div -no-prec-sqrt $WALLON -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG -std=c++11 -w2 -wd1125"
+    CPPFLAGS="-O2 -debug -no-prec-div -no-prec-sqrt $WALLON -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG"
   else
     CPPFLAGS="-O2 -g -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG $WALLON $INPUT_CPPFLAGS"
     CXXFLAGS="-O2 -g -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG -std=c++11 $WALLON $INPUT_CXXFLAGS"
@@ -173,8 +185,8 @@ AM_CONDITIONAL([ENABLEGPU_AM], [test "$want_cuda" = "yes"])
 # fftw
 
 AC_ARG_WITH(fftw-dir,
-[[  --with-fftw-dir=DIR     Declare the root directory of fftw3, if its 
-                          current location is not system accessible ]],
+AS_HELP_STRING([--with-fftw-dir=DIR],[Declare the root directory of fftw3, if its 
+                          current location is not system accessible ]),
 [
     if test "$withval" != "yes" -a "$withval" != ""; then
         CPPFLAGS="$CPPFLAGS -I$withval/include -L$withval/lib"
@@ -185,7 +197,7 @@ AC_ARG_WITH(fftw-dir,
 
 # experimental
 
-AC_ARG_ENABLE(experimental, [  --enable-experimental  Compile with experimental [[default=no]]],[
+AC_ARG_ENABLE(experimental, AS_HELP_STRING([--enable-experimental],[Compile with experimental [default=no]]),[
   if test "$enableval" = yes; then
   CPPFLAGS="$CPPFLAGS -DEXPERIMENTAL"
   CXXFLAGS="$CXXFLAGS -DEXPERIMENTAL"
@@ -195,7 +207,7 @@ AC_ARG_ENABLE(experimental, [  --enable-experimental  Compile with experimental 
  
 #rigorous socket check 
 
-AC_ARG_ENABLE(rigorous-sockets, [  --enable-rigorous-sockets  Use rigorous socket checking [[default=no]]],[
+AC_ARG_ENABLE(rigorous-sockets, AS_HELP_STRING([--enable-rigorous-sockets],[Use rigorous socket checking [default=no]]),[
   if test "$enableval" = yes; then
   CPPFLAGS="$CPPFLAGS -DRIGOROUS_SOCKET_CHECK"
   CXXFLAGS="$CXXFLAGS -DRIGOROUS_SOCKET_CHECK"  
@@ -205,7 +217,7 @@ AC_ARG_ENABLE(rigorous-sockets, [  --enable-rigorous-sockets  Use rigorous socke
 AM_CONDITIONAL([EXPERIMENTAL_AM],[test x$compile_experimental = xtrue])
 
 # OpenMP
-AC_ARG_ENABLE(openmp, [  --enable-openmp  Compile with OpenMP threading [[default=no]]],[
+AC_ARG_ENABLE(openmp, AS_HELP_STRING([--enable-openmp],[Compile with OpenMP threading [default=no]]),[
   if test "$enableval" = yes; then
   AC_OPENMP([],AC_MSG_ERROR("You asked for OpenMP, but I was not able to figure out how to compile programs that use OpenMP"))
   CXXFLAGS="$CXXFLAGS $OPENMP_CXXFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -168,6 +168,13 @@ AC_ARG_WITH([cuda], AS_HELP_STRING([--with-cuda@<:@=yes|no|DIR@:>@], [prefix whe
 if test "$want_cuda" = "yes" 
 then
 
+	use_gpu_cache_hints=""
+	AC_ARG_ENABLE(gpu-cache-hints, [  --disable-gpu-cache-hints          Do not use the intrinsics for cache hints ],[
+	  if test "$enableval" = no; then
+	  	use_gpu_cache_hints="-DDISABLECACHEHINTS"
+	  	AC_MSG_NOTICE([Disabling cache hint intrinsics requiring CUDA 11 or newer])  	
+	  fi])
+
 	# In Thrust 1.10 c++11 is deprecated. Not using those libs now, so squash warnings, but we should consider switching to a newer standard
 	AC_DEFINE(THRUST_IGNORE_DEPRECATED_CPP_11,true)
 
@@ -177,8 +184,8 @@ then
     AC_MSG_NOTICE([Adding the CUDA includes Setting up NVCC initial flags])
     CUDA_CPPFLAGS="$CUDA_CFLAGS $NVCCFLAGS"
     CUDA_CXXFLAGS="$CUDA_CFLAGS $NVCCFLAGS"
-    CXXFLAGS="$CXXFLAGS -DENABLEGPU $CUDA_CFLAGS"
-    CPPFLAGS="$CPPFLAGS -DENABLEGPU $CUDA_CFLAGS"
+    CXXFLAGS="$CXXFLAGS -DENABLEGPU $use_gpu_cache_hints $CUDA_CFLAGS"
+    CPPFLAGS="$CPPFLAGS -DENABLEGPU $use_gpu_cache_hints $CUDA_CFLAGS"
     AC_MSG_NOTICE([Using CUDA_CXXFLAGS=$CUDA_CXXFLAGS])
     AC_MSG_NOTICE([Using CUDA_LIBS=$CUDA_LIBS])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -2,6 +2,8 @@ AC_INIT(cisTEM, [2.0.0-alpha])
 AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_MACRO_DIR([m4])
 
+#TODO add help strings for all configure options!
+
 INPUT_CPPFLAGS="$CPPFLAGS"
 INPUT_CXXFLAGS="$CXXFLAGS"
 
@@ -143,44 +145,16 @@ AC_ARG_ENABLE(debugmode, [  --enable-debugmode      Compile in debug mode [[defa
   fi
   ])
   
-want_cuda="no"
+
 ###############################
 # BEGIN CUDA CHECKS AND SETS
 ###############################
-cuda_home_path="/usr/local/cuda"
-AC_MSG_NOTICE([Checking for gpu request and vars])
-AC_ARG_WITH([cuda], AS_HELP_STRING([--with-cuda@<:@=yes|no|DIR@:>@], [prefix where cuda is installed (default=no)]),
-[
-	with_cuda=$withval
-	if test "$withval" = "no"
-	then
-		want_cuda="no"
-	elif test "$withval" = "yes"
-	then
-		want_cuda="yes"
-	else
-		want_cuda="yes"
-		cuda_home_path=$withval
-	fi
-], [ want_cuda="no"] )
+want_cuda="no"
 
-
-if test "$want_cuda" = "yes" 
-then
-
-	use_gpu_cache_hints=""
-	AC_ARG_ENABLE(gpu-cache-hints, [  --disable-gpu-cache-hints          Do not use the intrinsics for cache hints ],[
-	  if test "$enableval" = no; then
-	  	use_gpu_cache_hints="-DDISABLECACHEHINTS"
-	  	AC_MSG_NOTICE([Disabling cache hint intrinsics requiring CUDA 11 or newer])  	
-	  fi])
-
-	# In Thrust 1.10 c++11 is deprecated. Not using those libs now, so squash warnings, but we should consider switching to a newer standard
-	AC_DEFINE(THRUST_IGNORE_DEPRECATED_CPP_11,true)
-
-	# Set conditional and run macro	
-	AX_CUDA
-	
+AX_CUDA  
+  	
+if test "$want_cuda" = "yes" ; then
+		
     AC_MSG_NOTICE([Adding the CUDA includes Setting up NVCC initial flags])
     CUDA_CPPFLAGS="$CUDA_CFLAGS $NVCCFLAGS"
     CUDA_CXXFLAGS="$CUDA_CFLAGS $NVCCFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -33,25 +33,35 @@ AC_MSG_NOTICE([Setting up initial flags])
 
 # check to see if compiler warnings are desired.
 
-AC_ARG_ENABLE([disable-warnings], AS_HELP_STRING([--disable compiler warnings], [Default=false]), [
+AC_ARG_ENABLE([disable-warnings], AS_HELP_STRING([--disable compiler warnings], [Default=false]), 
+[
+	# If flag do this
 	if test "x$enableval" = "no" ; then
-		WALLON=""
-		AC_MSG_NOTICE([DISABLE VAL $enableval])
-		
+		WARNINGS_ON=""		
 	else
-		WALLON="-Wall"
-				AC_MSG_NOTICE([ELSE VAL $enableval])
-		
+		if test "x$CXX" = "xicpc"; then		
+			WARNINGS_ON="-w2"
+		else
+			WARNINGS_ON="-Wall"	
+		fi		
 	fi
-], [WALLON="-Wall"])
+], 
+[ 
+		# If no flag do this
+		if test "x$CXX" = "xicpc"; then		
+			WARNINGS_ON="-w2"
+		else
+			WARNINGS_ON="-Wall"	
+		fi	
+])
 
 
 if test "x$CXX" = "xicpc"; then		
-	CXXFLAGS="$CXXFLAGS -O3 -no-prec-div -no-prec-sqrt $WALLON -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -std=c++11 -w2 -wd1125"
-	CPPFLAGS="$CPPFLAGS -O3 -no-prec-div -no-prec-sqrt $WALLON -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE"
+	CXXFLAGS="$CXXFLAGS -O3 -no-prec-div -no-prec-sqrt $WARNINGS_ON -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -std=c++11 -wd1125"
+	CPPFLAGS="$CPPFLAGS -O3 -no-prec-div -no-prec-sqrt $WARNINGS_ON -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE"
 else
-	CXXFLAGS="$CXXFLAGS -DNDEBUG -funroll-loops -O3 -pipe $WALLON -fexpensive-optimizations -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -std=c++11"		
-	CPPFLAGS="$CPPFLAGS -DNDEBUG -funroll-loops -O3 -pipe $WALLON -fexpensive-optimizations -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE"
+	CXXFLAGS="$CXXFLAGS -DNDEBUG -funroll-loops -O3 -pipe $WARNINGS_ON -fexpensive-optimizations -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -std=c++11"		
+	CPPFLAGS="$CPPFLAGS -DNDEBUG -funroll-loops -O3 -pipe $WARNINGS_ON -fexpensive-optimizations -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE"
 
 	#sqlite needs dl on gcc
 	
@@ -87,29 +97,32 @@ AM_CONDITIONAL([LINUX_AM], [test "$build_linux" = "yes"])
 AM_CONDITIONAL([WINDOWS_AM], [test "$build_windows" = "yes"])
 AM_CONDITIONAL([OSX_AM], [test "$build_mac" = "yes"])
 
-# Use all available processor instruction sets
-AC_ARG_ENABLE(latest-instruction-set, AS_HELP_STRING([--enable-latest-instruction-set],[Use latest available CPU instruction set [default=yes]]),[
-        AC_MSG_ERROR(["Enable val by default is $enableval"])
-
+# Use all available processor instruction sets - this defaults to no (I think) if the option is not flagged. See issue #296 on github
+instruction_set=""
+AC_ARG_ENABLE(latest-instruction-set, AS_HELP_STRING([--enable-latest-instruction-set],[Use the latest available CPU instruction set, only affects Intel compiler [default=yes]]),[
   if test "$enableval" = yes; then
-	if test "x$CXX" = "xicpc"; then	
-		CXXFLAGS="$CXXFLAGS -xHost"
-	fi
+	instruction_set=" -xHost -wd10382"
   fi
-])
+], [instruction_set=" -xHost -wd10382"])
 
-# MKL FIXME this looks like it is duplicated at line 134
+if test "x$CXX" = "xicpc"; then	
+	CXXFLAGS="$CXXFLAGS $instruction_set"
+fi
 
-AC_ARG_ENABLE(mkl, AS_HELP_STRING([--disable-mkl],[Do not use the Intel MKL]),[
-  if test "$enableval" = no; then
+# MKL
+
+use_mkl=1
+AC_ARG_ENABLE(mkl, AS_HELP_STRING([--disable-mkl],[Do not use the Intel MKL]),
+[
+ if test "$enableval" = no; then
         use_mkl=0
-  fi])
+ fi
+ ])
 
 
 # Static linking
 
 static_link="false"
-
 AC_ARG_ENABLE(staticmode, AS_HELP_STRING([--enable-staticmode],[Link statically [default=no]]),[
   if test "$enableval" = yes; then
 	static_link="true"
@@ -134,28 +147,24 @@ AS_HELP_STRING([--with-wx-config=FILE],[Use the given path to wx-config when det
     fi
 ])
 
-# MKL
 
-use_mkl=1
 
-AC_ARG_ENABLE(mkl, AS_HELP_STRING([--disable-mkl],[Do not use the Intel MKL]),[
-  if test "$enableval" = no; then
-  	use_mkl=0
-  fi])
+
 
 # debugmode
 
-AC_ARG_ENABLE(debugmode, AS_HELP_STRING([--enable-debugmode],[Compile in debug mode [default=no]]),[
+AC_ARG_ENABLE(debugmode, AS_HELP_STRING([--enable-debugmode],[Compile in debug mode [default=no]]),
+[
   if test "$enableval" = yes; then
   if test "x$CXX" = "xicpc"; then   
-    CXXFLAGS="-O2 -debug -no-prec-div -no-prec-sqrt $WALLON -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG -std=c++11 -w2 -wd1125"
-    CPPFLAGS="-O2 -debug -no-prec-div -no-prec-sqrt $WALLON -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG"
+    CXXFLAGS="-O2 -debug -no-prec-div -no-prec-sqrt $WARNINGS_ON -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG -std=c++11 -wd1125"
+    CPPFLAGS="-O2 -debug -no-prec-div -no-prec-sqrt $WARNINGS_ON -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG"
   else
-    CPPFLAGS="-O2 -g -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG $WALLON $INPUT_CPPFLAGS"
-    CXXFLAGS="-O2 -g -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG -std=c++11 $WALLON $INPUT_CXXFLAGS"
+    CPPFLAGS="-O2 -g -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG $WARNINGS_ON $INPUT_CPPFLAGS"
+    CXXFLAGS="-O2 -g -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG -std=c++11 $WARNINGS_ON $INPUT_CXXFLAGS"
   fi
   fi
-  ])
+ ])
   
 
 ###############################

--- a/configure.ac
+++ b/configure.ac
@@ -99,11 +99,11 @@ AM_CONDITIONAL([OSX_AM], [test "$build_mac" = "yes"])
 
 # Use all available processor instruction sets - this defaults to no (I think) if the option is not flagged. See issue #296 on github
 instruction_set=""
-AC_ARG_ENABLE(latest-instruction-set, AS_HELP_STRING([--enable-latest-instruction-set],[Use the latest available CPU instruction set, only affects Intel compiler [default=yes]]),[
+AC_ARG_ENABLE(latest-instruction-set, AS_HELP_STRING([--enable-latest-instruction-set],[Use the latest available CPU instruction set, only affects Intel compiler [default=no]]),[
   if test "$enableval" = yes; then
 	instruction_set=" -xHost -wd10382"
   fi
-], [instruction_set=" -xHost -wd10382"])
+]) #, [instruction_set=" -xHost -wd10382"]) if we wanted default to be yes, this fourth arg should be included.
 
 if test "x$CXX" = "xicpc"; then	
 	CXXFLAGS="$CXXFLAGS $instruction_set"

--- a/src/core/pdb.cpp
+++ b/src/core/pdb.cpp
@@ -267,7 +267,6 @@ void PDB::SetEmpty()
 		this->center_of_mass[2] = 0;
 	}
 
-
 }
 
 void PDB::Init()

--- a/src/core/pdb.h
+++ b/src/core/pdb.h
@@ -105,7 +105,6 @@ class PDB {
 		~PDB();
 
 		// data
-
 		long number_of_lines;
 		long number_of_atoms; // total atoms to simulate, active in this particle
 		long number_of_real_and_noise_atoms; // total atoms in the PDB object

--- a/src/core/water.cpp
+++ b/src/core/water.cpp
@@ -114,7 +114,6 @@ void Water::Init(const PDB *current_specimen, int wanted_size_neighborhood, floa
 //		}
 
 		wxPrintf("size post rot 2 padding %d %d padX %d padY %d padZ %d rot\n",vol_nX, vol_nY, *padX, *padY, padZ);
-
 		MyAssertTrue(current_specimen->pixel_size > 0.0f, "The pixel size for your PDB object is not yet set.");
 		// Copy over some values from the current specimen - Do these need to be updated for tilts and rotations?
 		this->vol_angX = vol_nX * current_specimen->pixel_size; //current_specimen->vol_angX;

--- a/src/gpu/GpuImage.cu
+++ b/src/gpu/GpuImage.cu
@@ -71,7 +71,7 @@ __device__ void CB_mipCCGAndStore(void* dataOut, size_t offset, cufftReal elemen
 //	data_out_half[offset] = __float2half(element);
 //	((cufftReal *)dataOut)[offset] = element;
 
-#ifdef DDISABLECACHEHINTS
+#ifdef DISABLECACHEHINTS
 	((__half *)dataOut)[offset] = __float2half(element);
 #else
 	__stcs( &data_out_half[offset], __float2half(element) );

--- a/src/gpu/GpuImage.cu
+++ b/src/gpu/GpuImage.cu
@@ -71,8 +71,11 @@ __device__ void CB_mipCCGAndStore(void* dataOut, size_t offset, cufftReal elemen
 //	data_out_half[offset] = __float2half(element);
 //	((cufftReal *)dataOut)[offset] = element;
 
-   __stcs( &data_out_half[offset], __float2half(element) );
-//	((__half *)dataOut)[offset] = __float2half(element);
+#ifdef DDISABLECACHEHINTS
+	((__half *)dataOut)[offset] = __float2half(element);
+#else
+	__stcs( &data_out_half[offset], __float2half(element) );
+#endif
 
 //	)_(dataOut)[offset] = __float2half(element);
 //

--- a/src/programs/match_template/match_template.cpp
+++ b/src/programs/match_template/match_template.cpp
@@ -2,7 +2,7 @@
 
 
 // Values for data that are passed around in the results.
-const int number_of_output_images = 8; //mip, scaledmip, psi, theta, phi, pixel, defocus, sums, sqsums
+const int number_of_output_images = 8; //mip, psi, theta, phi, pixel, defocus, sums, sqsums (scaled mip is not sent out)
 const int number_of_meta_data_values = 6; // img_x, img_y, number cccs, histogram values.
 const int MAX_ALLOWED_NUMBER_OF_PEAKS = 1000; // An error will be thrown and job aborted if this number of peaks is exceeded in the make template results block
 
@@ -1186,6 +1186,8 @@ bool MatchTemplateApp::DoCalculation()
 		max_intensity_projection.Rotate2DInPlaceBy90Degrees(false);
 
 		best_psi.Rotate2DInPlaceBy90Degrees(false);
+		// To account for the pre-rotation, psi needs to have 90 added to it.
+		best_psi.AddConstant(90.0f);
 		best_theta.Rotate2DInPlaceBy90Degrees(false);
 		best_phi.Rotate2DInPlaceBy90Degrees(false);
 		best_defocus.Rotate2DInPlaceBy90Degrees(false);

--- a/src/programs/refine_template/refine_template.cpp
+++ b/src/programs/refine_template/refine_template.cpp
@@ -25,11 +25,12 @@ public:
 Peak TemplateScore(void *scoring_parameters)
 {
 	TemplateComparisonObject *comparison_object = reinterpret_cast < TemplateComparisonObject *> (scoring_parameters);
-	//wxPrintf("Calculating Score %f %f %f %f %f \n",comparison_object->angles->ReturnPhiAngle()
-	//,comparison_object->angles->ReturnThetaAngle()
-	//,comparison_object->angles->ReturnPsiAngle()
-	//,comparison_object->angles->ReturnShiftX()
-	//,comparison_object->angles->ReturnShiftY());
+	
+	MyDebugPrint("Calculating Score %f %f %f %f %f \n",comparison_object->angles->ReturnPhiAngle()
+	,comparison_object->angles->ReturnThetaAngle()
+	,comparison_object->angles->ReturnPsiAngle()
+	,comparison_object->angles->ReturnShiftX()
+	,comparison_object->angles->ReturnShiftY());
 	Image current_projection;
 //	Peak box_peak;
 
@@ -800,7 +801,7 @@ bool RefineTemplateApp::DoCalculation()
 					starting_score = score_adjustment * scaled_mip_image.real_values[current_address] * starting_score / mip_image.real_values[current_address];
 
 					if (max_threads == 1) wxPrintf("\nRefining peak %i at x, y =  %6i, %6i\n", peak_number + 1, myroundint(current_peak.x), myroundint(current_peak.y));
-					if (angular_step == 0.0 | in_plane_angular_step == 0.0) {
+					if (angular_step == 0.0 & in_plane_angular_step == 0.0) {
 						if (max_threads == 1) wxPrintf("Peak %4i: dx, dy, dpsi, dtheta, dphi, ddefocus, dpixel size = %12.6f, %12.6f, %12.6f, %12.6f, %12.6f, %12.6f, %12.6f | value = %10.6f\n", peak_number + 1, 0.,0.,0.,0.,0.,0.,0., starting_score);
 						goto NEXTPEAK;
 					}										

--- a/src/programs/simulate/simulate.cpp
+++ b/src/programs/simulate/simulate.cpp
@@ -853,24 +853,24 @@ void SimulateApp::DoInteractiveUserInput()
 
 	 if (this->do3d)
 	 {
-//		 // Check to make sure the sampling is sufficient, if not, oversample and bin at the end.
-//		 if (this->wanted_pixel_size > 0.8 && this->wanted_pixel_size <= 1.5)
-//		 {
-//			 wxPrintf("\nOversampling your 3d by a factor of 2 for calculation.\n");
-//			 this->wanted_pixel_size /= 2.0f;
-//			 this->bin3d = 2;
-//		 }
-//		 else if (this->wanted_pixel_size > 1.5 && this->wanted_pixel_size < 3.0)
-//		 {
-//			 wxPrintf("\nOversampling your 3d by a factor of 4 for calculation.\n");
-//
-//			 this->wanted_pixel_size /= 4.0f;
-//			 this->bin3d = 4;
-//		 }
-//		 else
-//		 {
-//			 //do nothing
-//		 }
+		 // Check to make sure the sampling is sufficient, if not, oversample and bin at the end.
+		 if (this->wanted_pixel_size > 0.5 && this->wanted_pixel_size <= 1.5)
+		 {
+			 wxPrintf("\nOversampling your 3d by a factor of 2 for calculation.\n");
+			 this->wanted_pixel_size /= 2.0f;
+			 this->bin3d = 2;
+		 }
+		 else if (this->wanted_pixel_size > 1.5 && this->wanted_pixel_size < 3.0)
+		 {
+			 wxPrintf("\nOversampling your 3d by a factor of 4 for calculation.\n");
+
+			 this->wanted_pixel_size /= 4.0f;
+			 this->bin3d = 4;
+		 }
+		 else
+		 {
+			 //do nothing
+		 }
 		 this->dose_per_frame			= my_input->GetFloatFromUser("electrons/Ang^2 in a frame at the specimen","","1.0",0.05,20.0);
 		 this->number_of_frames			= my_input->GetFloatFromUser("number of frames per movie (micrograph or tilt)","","30",1.0,1000.0);
 


### PR DESCRIPTION
Just for your reference, I also experimented with generating a no-refine version. I used a goto statement to jump over all the code that as you said is somewhat opaque. This way the TemplateScore function is called only one per peak.

