### PR TITLE
Add Tegunov-style wiener filter to applyctf & allow ctffind to work on low-mag images

### DIFF
--- a/src/core/image.cpp
+++ b/src/core/image.cpp
@@ -1407,7 +1407,7 @@ void Image::WeightBySSNR(Image &ctf_image, float molecular_mass_kDa, float pixel
  * are probably not needed.
  *
  */
-void Image::OptimalFilterWarp(CTF ctf, float pixel_size_in_angstroms, float ssnr_falloff_fudge_factor, float ssnr_scale_fudge_factor)
+void Image::OptimalFilterWarp(CTF ctf, float pixel_size_in_angstroms,float ssnr_falloff_frequency, float ssnr_falloff_fudge_factor, float ssnr_scale_fudge_factor, float hp_frequency)
 {
 	MyDebugAssertTrue(is_in_memory, "Memory not allocated");
 	MyDebugAssertTrue(is_in_real_space == false, "image not in Fourier space");
@@ -1432,9 +1432,9 @@ void Image::OptimalFilterWarp(CTF ctf, float pixel_size_in_angstroms, float ssnr
 	float ssnr_value_pre_ctf;
 	float filter_value;
 
-	const float ssnr_falloff_characteristic_spacing = 100.0 / pixel_size_in_angstroms * ssnr_falloff_fudge_factor; // 100A was suggested by Tegunov, seems to work well
+	const float ssnr_falloff_characteristic_spacing = ssnr_falloff_frequency / pixel_size_in_angstroms * ssnr_falloff_fudge_factor; // 100A was suggested by Tegunov, seems to work well
 	const float ssnr_peak_scale_factor = powf(10.0,3.0*ssnr_scale_fudge_factor);
-	const float hp_radius = 1.0/200.0*pixel_size_in_angstroms;
+	const float hp_radius = 1.0/hp_frequency*pixel_size_in_angstroms;
 	const float hp_width = 1.0 * hp_radius;
 	const float hp_radius_start_squared = powf(hp_radius - 0.5*hp_width,2);
 	const float hp_radius_finish_squared = powf(hp_radius + 0.5*hp_width,2);

--- a/src/core/image.h
+++ b/src/core/image.h
@@ -134,7 +134,7 @@ public:
 	void WeightBySSNR(Image &ctf_image, float molecular_mass_kDa, float pixel_size, Curve &SSNR, Image &projection_image, bool weight_particle_image, bool weight_projection_image);
 	void OptimalFilterSSNR(Curve &SSNR);
 	void OptimalFilterFSC(Curve &FSC);
-	void OptimalFilterWarp(CTF ctf, float pixel_size_in_angstroms, float ssnr_falloff_fudge_factor = 1.0, float ssnr_scale_fudge_factor = 1.0);
+	void OptimalFilterWarp(CTF ctf, float pixel_size_in_angstroms, float ssnr_falloff_frequency = 100.0, float ssnr_falloff_fudge_factor = 1.0, float ssnr_scale_fudge_factor = 1.0, float hp_frequency=200.0);
 	//float Correct3D(float wanted_mask_radius = 0.0);
 	float CorrectSinc(float wanted_mask_radius = 0.0, float padding_factor = 1.0, bool force_background_value = false, float wanted_mask_value = 0.0);
 	void MirrorXFourier2D(Image &mirrored_image);

--- a/src/programs/applyctf/applyctf.cpp
+++ b/src/programs/applyctf/applyctf.cpp
@@ -34,6 +34,12 @@ void ApplyCTFApp::DoInteractiveUserInput()
 
 	bool input_ctf_values_from_text_file;
 	bool phase_flip_only;
+	bool apply_wiener_filter = false;
+
+	float wiener_filter_falloff_frequency = 100.0;
+	float wiener_filter_falloff_fudge_factor = 1.0;
+	float wiener_filter_scale_fudge_factor = 1.0;
+	float wiener_filter_hp_radius = 200.0;
 
 	bool set_expert_options;
 
@@ -62,12 +68,24 @@ void ApplyCTFApp::DoInteractiveUserInput()
 
 	phase_flip_only = my_input->GetYesNoFromUser("Phase Flip Only", "If Yes, only phase flipping is performed", "NO");
 
+	if (phase_flip_only == false)
+	{
+		apply_wiener_filter = my_input->GetYesNoFromUser("Apply Wiener Filter", "If Yes, apply Wiener filter as suggested by Tegunov, et.al.","NO");
+	}
+	if (apply_wiener_filter == true)
+	{
+		wiener_filter_falloff_frequency = my_input->GetFloatFromUser("SSNR Falloff frequency","In Angstromsm, the frequency at which SSNR falls off","100.0");
+		wiener_filter_falloff_fudge_factor = my_input->GetFloatFromUser("SSNR Falloff speed","How fast does SSNR fall off","1.0");
+		wiener_filter_scale_fudge_factor = my_input->GetFloatFromUser("Deconvolution strength","Strength of the deconvolution","1.0");
+		wiener_filter_hp_radius = my_input->GetFloatFromUser("Highpass filter frequency","In Angstromsm, the frequency at which to cutoff low freq signal","200.0");
+
+	}
 
 
 	delete my_input;
 
 	my_current_job.Reset(10);
-	my_current_job.ManualSetArguments("ttffffffffbtb",     	 input_filename.c_str(),
+	my_current_job.ManualSetArguments("ttffffffffbtbbffff",     	 input_filename.c_str(),
 															 output_filename.c_str(),
 															 pixel_size,
 															 acceleration_voltage,
@@ -79,7 +97,12 @@ void ApplyCTFApp::DoInteractiveUserInput()
 															 additional_phase_shift,
 															 input_ctf_values_from_text_file,
 															 text_filename.c_str(),
-															 phase_flip_only
+															 phase_flip_only,
+															 apply_wiener_filter,
+															 wiener_filter_falloff_frequency,
+															 wiener_filter_falloff_fudge_factor,
+															 wiener_filter_scale_fudge_factor,
+															 wiener_filter_hp_radius
 															 );
 
 
@@ -109,7 +132,12 @@ bool ApplyCTFApp::DoCalculation()
 	bool        input_ctf_values_from_text_file     = my_current_job.arguments[10].ReturnBoolArgument();
 	std::string text_filename                       = my_current_job.arguments[11].ReturnStringArgument();
 	bool        phase_flip_only                     = my_current_job.arguments[12].ReturnBoolArgument();
+	bool        apply_wiener_filter                 = my_current_job.arguments[13].ReturnBoolArgument();
 
+	float 		wiener_filter_falloff_frequency 	= my_current_job.arguments[14].ReturnFloatArgument();
+	float 		wiener_filter_falloff_fudge_factor 	= my_current_job.arguments[15].ReturnFloatArgument();
+	float 		wiener_filter_scale_fudge_factor 	= my_current_job.arguments[16].ReturnFloatArgument();
+	float 		wiener_filter_hp_radius 			= my_current_job.arguments[17].ReturnFloatArgument();	
 	float temp_float[5];
 
 	ProgressBar			*my_progress_bar;
@@ -165,9 +193,19 @@ bool ApplyCTFApp::DoCalculation()
 			}
 		}
 
-		if (phase_flip_only == true) current_image.ApplyCTFPhaseFlip(current_ctf);
-		else current_image.ApplyCTF(current_ctf);
+		if (phase_flip_only == true) {current_image.ApplyCTFPhaseFlip(current_ctf);}
+		else if (apply_wiener_filter == true) {current_image.OptimalFilterWarp(current_ctf,
+											   pixel_size,
+											   wiener_filter_falloff_frequency, 
+											   wiener_filter_falloff_fudge_factor,
+											   wiener_filter_scale_fudge_factor,
+											   wiener_filter_hp_radius);}
+		else {current_image.ApplyCTF(current_ctf);}
+		//current_image.ZeroCentralPixel();
 		current_image.BackwardFFT();
+		if (apply_wiener_filter == false) {
+			current_image.InvertRealValues();
+		}
 		current_image.WriteSlice(&output_file,image_counter + 1 );
 
 		my_progress_bar->Update(image_counter + 1);


### PR DESCRIPTION
This pull request does two things:

- It allows the applyctf program to apply the Tegunov-style wiener as implemented in the image class
- It adds a command-line flag to ctffind that allows setting the minimum resolution to arbitrary values

The use case for this at the moment is to apply the filter to low-magnification images with ~4 nm pixel-size.